### PR TITLE
[US-002] Feature: expose technical coverage viability API

### DIFF
--- a/force-app/main/default/classes/ConnectMaxCoverageAPI.cls
+++ b/force-app/main/default/classes/ConnectMaxCoverageAPI.cls
@@ -1,0 +1,71 @@
+@RestResource(urlMapping='/api/v1/coverageCheck/*')
+global with sharing class ConnectMaxCoverageAPI {
+    global class CoverageResponse {
+        global Boolean success { get; set; }
+        global String message { get; set; }
+        global String cepConsulta { get; set; }
+        global Boolean hasCoverage { get; set; }
+        global String maxSpeed { get; set; }
+
+        global CoverageResponse(Boolean success, String message, String cep, Boolean coverage, String speed) {
+            this.success = success;
+            this.message = message;
+            this.cepConsulta = cep;
+            this.hasCoverage = coverage;
+            this.maxSpeed = speed;
+        }
+    }
+
+    @HttpGet
+    global static void checkCoverage() {
+        RestRequest req = RestContext.request;
+        RestResponse res = RestContext.response;
+        CoverageResponse responseBody;
+
+        String cep = '';
+
+        try {
+            cep = req.requestURI.substring(req.requestURI.lastIndexOf('/') + 1);
+            List<Coverage_Area__c> coverageList = [ 
+                SELECT Has_Fiber_Coverage__c, Max_Speed_Available__c 
+                FROM Coverage_Area__c
+                WHERE CEP__c = :cep
+                LIMIT 1
+            ];
+
+            if(!coverageList.isEmpty()) {
+                Coverage_Area__c area = coverageList[0];
+                responseBody = new CoverageResponse(
+                    true,
+                    'Consulta realizada com sucesso',
+                    cep,
+                    area.Has_Fiber_Coverage__c,
+                    area.Max_Speed_Available__c
+                );
+
+                res.statusCode = 200;
+            } else {
+                responseBody = new CoverageResponse(
+                        true, 
+                        'Região não atendida pela ConnectMax.', 
+                        cep, 
+                        false, 
+                        null
+                    );
+                    res.statusCode = 200;
+            }
+        } catch (Exception e) {
+            responseBody = new CoverageResponse(
+                false,
+                'Erro interno no servidor ' + e.getMessage(),
+                cep,
+                false,
+                null
+            );
+            res.statusCode = 500;
+        }
+
+        res.addHeader('Content-Type', 'application/json');
+        res.responseBody = Blob.valueOf(JSON.serialize(responseBody));
+    }
+}

--- a/force-app/main/default/classes/ConnectMaxCoverageAPI.cls-meta.xml
+++ b/force-app/main/default/classes/ConnectMaxCoverageAPI.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>65.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/ConnectMaxCoverageAPI_Test.cls
+++ b/force-app/main/default/classes/ConnectMaxCoverageAPI_Test.cls
@@ -1,0 +1,107 @@
+/**
+ * This class contains unit tests for validating the behavior of Apex classes
+ * and triggers.
+ *
+ * Unit tests are class methods that verify whether a particular piece
+ * of code is working properly. Unit test methods take no arguments,
+ * commit no data to the database, and are flagged with the testMethod
+ * keyword in the method definition.
+ *
+ * All test methods in an org are executed whenever Apex code is deployed
+ * to a production org to confirm correctness, ensure code
+ * coverage, and prevent regressions. All Apex classes are
+ * required to have at least 75% code coverage in order to be deployed
+ * to a production org. In addition, all triggers must have some code coverage.
+ * 
+ * The @isTest class annotation indicates this class only contains test
+ * methods. Classes defined with the @isTest annotation do not count against
+ * the org size limit for all Apex scripts.
+ *
+ * See the Apex Language Reference for more information about Testing and Code Coverage.
+ */
+@isTest
+private class ConnectMaxCoverageAPI_Test {
+
+    @TestSetup
+    static void makeData(){
+        Coverage_Area__c testArea = new Coverage_Area__c(
+            CEP__c = '12345678',
+            Has_Fiber_Coverage__c = true,
+            Max_Speed_Available__c = '600 Mbps'
+        );
+        insert testArea;
+    }
+
+    @isTest
+    static void CoverageAPIhasCoverageTest() {
+        RestRequest req = new RestRequest(); 
+        RestResponse res = new RestResponse();
+
+        String cep = '12345678';
+        req.requestURI = '/services/apexrest/api/v1/coverageCheck/' + cep;
+        req.httpMethod = 'GET';
+        RestContext.request = req;
+        RestContext.response = res;
+
+        Test.startTest();
+        ConnectMaxCoverageAPI.checkCoverage();
+        Test.stopTest();
+
+        System.assertEquals(200, res.statusCode, 'O status code deveria ser 200');
+        
+        String jsonResponse = res.responseBody.toString();
+        Map<String, Object> result = (Map<String, Object>) JSON.deserializeUntyped(jsonResponse);
+        
+        System.assertEquals(true, result.get('success'), 'O success deveria ser true');
+        System.assertEquals(true, result.get('hasCoverage'), 'Deveria ter cobertura para este CEP');
+        System.assertEquals('600 Mbps', result.get('maxSpeed'), 'A velocidade deveria ser 600 Mbps');
+    }
+
+    @isTest
+    static void CoverageAPIhasNoCoverageTest() {
+        RestRequest req = new RestRequest(); 
+        RestResponse res = new RestResponse();
+        
+        String cep = '00000000';
+        req.requestURI = '/services/apexrest/api/v1/coverageCheck/' + cep;
+        req.httpMethod = 'GET';
+        RestContext.request = req;
+        RestContext.response = res;
+
+        Test.startTest();
+        ConnectMaxCoverageAPI.checkCoverage();
+        Test.stopTest();
+
+        System.assertEquals(200, res.statusCode, 'O status code deveria ser 200 mesmo sem cobertura (a API não falhou, só não achou o cpf)');
+        
+        String jsonResponse = res.responseBody.toString();
+        Map<String, Object> result = (Map<String, Object>) JSON.deserializeUntyped(jsonResponse);
+        
+        System.assertEquals(true, result.get('success'), 'A chamada da API teve sucesso');
+        System.assertEquals(false, result.get('hasCoverage'), 'Não deveria ter cobertura para este CEP');
+        System.assertEquals(null, result.get('maxSpeed'), 'A velocidade deveria ser nula');
+    }
+
+    @isTest
+    static void CoverageAPIServerErrorTest() {
+        RestRequest req = new RestRequest(); 
+        RestResponse res = new RestResponse();
+        
+        req.requestURI = null; 
+        req.httpMethod = 'GET';
+        RestContext.request = req;
+        RestContext.response = res;
+
+        Test.startTest();
+        ConnectMaxCoverageAPI.checkCoverage();
+        Test.stopTest();
+
+        System.assertEquals(500, res.statusCode, 'O status code deveria ser 500 devido ao requestURI ser nulo');
+        
+        String jsonResponse = res.responseBody.toString();
+        Map<String, Object> result = (Map<String, Object>) JSON.deserializeUntyped(jsonResponse);
+        
+        System.assertEquals(false, result.get('success'), 'A requisição deveria ter falhado (success = false)');
+        System.assertEquals(false, result.get('hasCoverage'), 'A cobertura deve ser false em caso de erro');
+    }
+}

--- a/force-app/main/default/classes/ConnectMaxCoverageAPI_Test.cls-meta.xml
+++ b/force-app/main/default/classes/ConnectMaxCoverageAPI_Test.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>65.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
# Exposição de Serviço de Viabilidade Técnica (API)

## Descrição
Como um sistema de vendas externo, eu quero poder consultar a viabilidade técnica informando um CEP, para que eu possa informar ao cliente final se a ConnectMax atende o endereço dele e quais velocidades estão disponíveis antes de iniciar o processo de venda.

## Critérios de Aceite (Definition of Done)

- [x] O endpoint REST deve estar acessível via método `GET` na rota `/api/v1/coverageCheck/`.
- [x] O serviço deve extrair o CEP passado na própria URL da requisição.
- [x] O sistema deve consultar o objeto `Coverage_Area__c` filtrando pelo CEP informado.
- [x] Se o CEP existir e possuir cobertura (`Has_Fiber_Coverage__c = true`), a API deve retornar um status HTTP 200 e um JSON contendo a mensagem de sucesso, o CEP consultado, um booleano de confirmação e a lista de velocidades disponíveis.
- [x] Se o CEP não existir ou não tiver cobertura, a API deve retornar um status HTTP 200, indicando no JSON que a região não é atendida e uma lista de velocidades vazia.
- [x] Erros de processamento interno devem retornar status HTTP 500 com uma mensagem amigável no JSON.
- [x] O código deve estar coberto por uma Classe de Teste (`@isTest`) com no mínimo 90% de cobertura de código, validando os cenários de sucesso, CEP não encontrado e erro estrutural.

**Notas Técnicas**

* Utilizar a anotação `@RestResource` e `@HttpGet`.
* Criar uma classe *Wrapper* interna para formatar a estrutura do JSON de resposta.
