### PR TITLE
[US-003] Feature: consume technical coverage viability API

### DIFF
--- a/force-app/main/default/classes/ConnectMaxCoverageCallout.cls
+++ b/force-app/main/default/classes/ConnectMaxCoverageCallout.cls
@@ -1,0 +1,68 @@
+public with sharing class ConnectMaxCoverageCallout {
+    
+    public class FlowInput {
+        @InvocableVariable(label='CEP para consulta' description='O CEP que será consultado na API' required=true)
+        public String cep;
+    }
+
+    public class FlowOutput {
+        @InvocableVariable(label='Sucesso na Chamada')
+        public Boolean success;
+
+        @InvocableVariable(label='Possui Cobertura')
+        public Boolean hasCoverage;
+
+        @InvocableVariable(label='Velocidade Máxima')
+        public String maxSpeed;
+
+        @InvocableVariable(label='Mensagem de Retorno')
+        public String message;
+    }
+
+    @InvocableMethod(label='Consultar Cobertura ConnectMax' description='Faz a chamada para a API interna de verificação de viabilidade técnica.')
+    public static List<FlowOutput> checkCoverageFromFlow(List<FlowInput> inputs) {
+        List<FlowOutput> results = new List<FlowOutput>();
+
+        for(FlowInput input : inputs) {
+            results.add(makeCallout(input.cep));
+        }
+
+        return results;
+    }
+
+    public static FlowOutPut makeCallOut(String cep) {
+        FlowOutput output = new FlowOutput();
+
+        try {
+            Http http = new Http();
+            HttpRequest request = new HttpRequest();
+
+            String baseUrl = Url.getOrgDomainUrl().toExternalForm();
+            request.setEndpoint(baseUrl +  '/services/apexrest/api/v1/coverageCheck/' + cep);
+            request.setMethod('GET');
+            request.setHeader('Authorization', 'Bearer ' + UserInfo.getSessionId());
+            request.setHeader('Content-Type', 'application/json');
+
+            HttpResponse response = http.send(request);
+
+            if(response.getStatusCode() == 200) {
+                Map<String,Object> jsonResponse = (Map<String, Object>) JSON.deserializeUntyped(response.getBody());
+
+                output.success = (Boolean) jsonResponse.get('success');
+                output.hasCoverage = (Boolean) jsonResponse.get('hasCoverage');
+                output.maxSpeed = (String) jsonResponse.get('maxSpeed');
+                output.message = (String) jsonResponse.get('message');
+            } else {
+                output.success = false;
+                output.hasCoverage = false;
+                output.message = 'Erro na API: Status Code ' + response.getStatusCode();
+            }
+        } catch (Exception e) {
+            output.success = false;
+            output.hasCoverage = false;
+            output.message = 'Erro de Callout: ' + e.getMessage();
+        }
+        
+        return output;
+    }
+}

--- a/force-app/main/default/classes/ConnectMaxCoverageCallout.cls-meta.xml
+++ b/force-app/main/default/classes/ConnectMaxCoverageCallout.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>65.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/ConnectMaxCoverageCallout_Test.cls
+++ b/force-app/main/default/classes/ConnectMaxCoverageCallout_Test.cls
@@ -1,0 +1,80 @@
+/**
+ * This class contains unit tests for validating the behavior of Apex classes
+ * and triggers.
+ *
+ * Unit tests are class methods that verify whether a particular piece
+ * of code is working properly. Unit test methods take no arguments,
+ * commit no data to the database, and are flagged with the testMethod
+ * keyword in the method definition.
+ *
+ * All test methods in an org are executed whenever Apex code is deployed
+ * to a production org to confirm correctness, ensure code
+ * coverage, and prevent regressions. All Apex classes are
+ * required to have at least 75% code coverage in order to be deployed
+ * to a production org. In addition, all triggers must have some code coverage.
+ * 
+ * The @isTest class annotation indicates this class only contains test
+ * methods. Classes defined with the @isTest annotation do not count against
+ * the org size limit for all Apex scripts.
+ *
+ * See the Apex Language Reference for more information about Testing and Code Coverage.
+ */
+@isTest
+private class ConnectMaxCoverageCallout_Test {
+
+    private class ConnectMaxCoverageMock implements HttpCalloutMock {
+        private Integer statusCode;
+        private String responseBody;
+
+        public ConnectMaxCoverageMock(Integer code, String body) {
+            this.statusCode = code;
+            this.responseBody = body;
+        }
+
+        public HttpResponse respond(HttpRequest req) {
+            HttpResponse res = new HttpResponse();
+            res.setHeader('Content-Type', 'application/json');
+            res.setBody(this.responseBody);
+            res.setStatusCode(this.statusCode);
+            return res;
+        }
+    }
+
+    @isTest
+    static void testCalloutSuccessWithCoverage() {
+        String mockJsonResponse = '{"success":true,"message":"Consulta realizada com sucesso.","cepConsulta":"12345678","hasCoverage":true,"maxSpeed":"600 Mbps"}';
+
+        Test.setMock(HttpCalloutMock.class, new ConnectMaxCoverageMock(200, mockJsonResponse));
+
+        ConnectMaxCoverageCallout.FlowInput input = new ConnectMaxCoverageCallout.FlowInput();
+        input.cep = '12345678';
+        List<ConnectMaxCoverageCallout.FlowInput> inputListForFlow = new List<ConnectMaxCoverageCallout.FlowInput>{ input };
+
+        Test.startTest();
+        List<ConnectMaxCoverageCallout.FlowOutput> results = ConnectMaxCoverageCallout.checkCoverageFromFlow(inputListForFlow);
+        Test.stopTest();
+
+        System.assertEquals(1, results.size(), 'Deveria retornar 1 resultado na lista');
+        System.assertEquals(true, results[0].success, 'A chamada deveria ser marcada como sucesso');
+        System.assertEquals(true, results[0].hasCoverage, 'Deveria identificar que tem cobertura');
+        System.assertEquals('600 Mbps', results[0].maxSpeed, 'A velocidade mapeada deveria ser 600 Mbps');
+    }
+
+    @isTest
+    static void testCalloutApiError() {
+        String mockJsonResponse = '{"success":false,"message":"Erro interno no servidor","cepConsulta":"000","hasCoverage":false,"maxSpeed":null}';
+
+        Test.setMock(HttpCalloutMock.class, new ConnectMaxCoverageMock(500, mockJsonResponse));
+
+        ConnectMaxCoverageCallout.FlowInput input = new ConnectMaxCoverageCallout.FlowInput();
+        input.cep = '000';
+
+        Test.startTest();
+        List<ConnectMaxCoverageCallout.FlowOutput> results = ConnectMaxCoverageCallout.checkCoverageFromFlow(new List<ConnectMaxCoverageCallout.FlowInput>{ input });
+        Test.stopTest();
+        
+        System.assertEquals(false, results[0].success, 'O FlowOutput deveria marcar false para o sucesso da API');
+        System.assertEquals(false, results[0].hasCoverage, 'Não deveria haver cobertura listada em caso de erro');
+        System.assert(results[0].message.contains('Status Code 500'), 'A mensagem deveria refletir o erro 500 do HTTP');
+    }
+}

--- a/force-app/main/default/classes/ConnectMaxCoverageCallout_Test.cls-meta.xml
+++ b/force-app/main/default/classes/ConnectMaxCoverageCallout_Test.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>65.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
# Consumo Interno de Viabilidade Técnica (Callout)

## Descrição
Como um agente de vendas utilizando o Salesforce (via Flow ou OmniScript), eu quero digitar o CEP do cliente e ter o sistema verificando a cobertura automaticamente, sem que eu precise abrir outra tela ou sistema de consulta, garantindo agilidade no atendimento e evitando vendas para áreas sem viabilidade.

## Critérios de Aceite (Definition of Done)

- [x] Deve existir uma Classe Apex responsável por realizar a integração (HTTP Callout) com o barramento de serviços.
- [x] A classe deve conter um método anotado com `@InvocableMethod` para permitir que Administradores Salesforce utilizem essa integração dentro de um **Screen Flow** ou **Process Automation** no futuro.
- [x] O método deve montar a requisição HTTP (endpoint criado em https://github.com/sarahrubia/connectmax-salesforce-portfolio/issues/2), realizar a chamada e desserializar o JSON de resposta retornado pela API.
- [x] O método deve retornar uma variável ou objeto estruturado para o Flow/OmniScript indicando se a venda pode prosseguir (booleano) e quais velocidades podem ser ofertadas.
- [x] O código deve ser coberto por uma Classe de Teste (`@isTest`) utilizando a interface `HttpCalloutMock` para simular as respostas da API sem realizar chamadas reais durante a execução do teste.

**Notas Técnicas:**

* Configurar *Named Credentials* ou *Remote Site Settings* na Org (se necessário) para permitir que o Salesforce chame sua própria URL.
* Utilizar as classes `HttpRequest`, `Http`, e `HttpResponse`.

# Evidências

<img width="614" height="195" alt="Captura de tela 2026-03-03 160112" src="https://github.com/user-attachments/assets/98f707cc-8e0a-479a-bb79-5b9f00f0f277" />
